### PR TITLE
Upgraded to be compatible with .Net 7.0

### DIFF
--- a/src/Weikio.NugetDownloader/ConsoleLogger.cs
+++ b/src/Weikio.NugetDownloader/ConsoleLogger.cs
@@ -33,6 +33,9 @@ namespace Weikio.NugetDownloader
                 case LogLevel.Error:
                     Console.WriteLine($"ERROR - {message}");
                     break;
+                
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
         }
 

--- a/src/Weikio.NugetDownloader/FolderProjectContext.cs
+++ b/src/Weikio.NugetDownloader/FolderProjectContext.cs
@@ -16,13 +16,13 @@ namespace Weikio.NugetDownloader
             _logger = logger;
         }
 
-        public ExecutionContext ExecutionContext => null;
+        public ExecutionContext? ExecutionContext => null;
 
-        public PackageExtractionContext PackageExtractionContext { get; set; }
+        public PackageExtractionContext PackageExtractionContext { get; set; } = null!;
 
-        public XDocument OriginalPackagesConfig { get; set; }
+        public XDocument? OriginalPackagesConfig { get; set; }
 
-        public ISourceControlManagerProvider SourceControlManagerProvider => null;
+        public ISourceControlManagerProvider? SourceControlManagerProvider => null;
 
         public void Log(MessageLevel level, string message, params object[] args)
         {
@@ -48,6 +48,9 @@ namespace Weikio.NugetDownloader
                 case MessageLevel.Error:
                     _logger.LogError(message);
                     break;
+                
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(level), level, null);
             }
         }
 

--- a/src/Weikio.NugetDownloader/IsExternalInit.cs
+++ b/src/Weikio.NugetDownloader/IsExternalInit.cs
@@ -1,0 +1,7 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    public class IsExternalInit
+    {
+    
+    }
+}

--- a/src/Weikio.NugetDownloader/NuGetFeed.cs
+++ b/src/Weikio.NugetDownloader/NuGetFeed.cs
@@ -5,16 +5,16 @@ namespace Weikio.NugetDownloader
     {
         public string Name { get; }
 
-        public string Feed { get; }
+        public string? Feed { get; }
 
-        public NuGetFeed(string name, string feed = null)
+        public NuGetFeed(string name, string? feed = null)
         {
             Name = name;
             Feed = feed;
         }
 
-        public string Username { get; set; }
+        public string? Username { get; set; }
 
-        public string Password { get; set; }
+        public string? Password { get; set; }
     }
 }

--- a/src/Weikio.NugetDownloader/Weikio.NugetDownloader.csproj
+++ b/src/Weikio.NugetDownloader/Weikio.NugetDownloader.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Tool for downloading and installing NuGet packages from .NET.</Description>
@@ -13,16 +17,19 @@
     <Title>NuGet Downloader</Title>
     <RepositoryUrl>https://github.com/weikio/NugetDownloader</RepositoryUrl>
     <PackageProjectUrl>https://github.com/weikio/NugetDownloader</PackageProjectUrl>
+    <LangVersion>11</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.PackageManagement" Version="5.9.1" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="5.9.1" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.9.1" />
-    <PackageReference Include="NuGet.Protocol" Version="5.9.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.6"/>
+    <PackageReference Include="NuGet.PackageManagement" Version="6.5.0" />
+    <PackageReference Include="NuGet.Packaging.Core" Version="6.5.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.5.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
+    <PackageReference Update="MinVer" Version="4.3.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
- Upgraded to be compatible with .Net 7.0
- Updated to be compatible with nullable reference types
- Updated dependencies

I built and deployed the package to a test NuGet instance. I imported the test package into a fork of [PluginFramework](https://github.com/weikio/PluginFramework) that I [upgraded to .Net 7.0](https://github.com/weikio/PluginFramework/pull/78). I ran all the tests against that new build, and everything succeeded. 